### PR TITLE
Partialy applied type functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,13 @@
   },
   "license": "MIT",
   "peerDependencies": {
-    "typescript": ">= 3.5.0-rc"
+    "typescript": ">= 3.5.3"
   },
   "devDependencies": {
-    "typescript": "3.5.0-dev.20190525"
+    "typescript": "3.5.3",
+    "typescript-language-server": "^0.3.8"
   },
   "resolutions": {
-    "typescript": "3.5.0-dev.20190525"
+    "typescript": "3.5.3"
   }
 }

--- a/src/generics.ts
+++ b/src/generics.ts
@@ -35,7 +35,10 @@ export namespace Generic {
   /**
    * A marker symbol for associating values of `T<A>` to `Generic<TRepr, A>`.
    */
-  export const Type: unique symbol = Symbol("tshkt:Generic.Type")
+  export const Type1: unique symbol = Symbol("tshkt:Generic.Type")
+  export const Type2: unique symbol = Symbol("tshkt:Generic.Type2")
+  export const Type3: unique symbol = Symbol("tshkt:Generic.Type3")
+  export const Type4: unique symbol = Symbol("tshkt:Generic.Type4")
 }
 
 /**
@@ -56,5 +59,14 @@ export namespace Generic {
  * ```
  */
 export interface HasGeneric<G> {
-  [Generic.Type]: G
+  [Generic.Type1]: G
+}
+export interface HasGeneric2<G> {
+  [Generic.Type2]: G
+}
+export interface HasGeneric3<G> {
+  [Generic.Type3]: G
+}
+export interface HasGeneric4<G> {
+  [Generic.Type4]: G
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,8 +1,7 @@
 import { Generic, TypeFamily, Of, Kind1, Generic1, Kind2, Generic2, Of2 } from ".";
-import { Carrier2 } from "./generics"
 
 declare class Box<A> {
-  [Generic.Type]: Generic1<BoxF, A>
+  [Generic.Type1]: Generic1<BoxF, A>
 
   readonly value: A
 }
@@ -85,14 +84,38 @@ namespace test$6 {
 
 // Tests kinds * -> * -> *
 namespace test$7 {
-  class Pair<A, B> {
-    [Generic.Type]: Generic2<Pair$λ, A, B>
-    constructor(readonly _0: A, readonly _1: B) {}
+  class Pair<A, B>
+    implements Functor<PairF<A>, B> {
+      [Generic.Type1]: Generic1<PairF<A>, B>
+      [Generic.Type2]: Generic2<Pair$λ, A, B>
+      constructor(readonly _0: A, readonly _1: B) {}
+
+      map <C>(_f: (b: B) => C): Pair<A, C> {
+        return this as any
+      }
+
+      swap (): Pair<B, A> {
+        return new Pair(this._1, this._0)
+      }
   }
 
   interface Pair$λ extends TypeFamily<Kind2> {
     (): Pair<this[0], this[1]>
   }
+
+  interface PairF<A> extends TypeFamily<Kind1> {
+    (): Pair<A, this[0]>
+  }
+
+  interface Functor<F, A> {
+    map <B>(this: Of<F, A>, f: (a: A) => B): Of<F, B>
+  }
+
+  interface IsFunctor<F> extends TypeFamily<Kind1> {
+    (): Functor<F, this[0]>
+  }
+
+  declare function map <F extends IsFunctor<F>, A, B>(f: (a: A) => B, fa: Of<F, A>): Of<F, A>
 
   declare function infer2<T extends TypeFamily<Kind2>, A1, A2>(t: Of2<T, A1, A2>): Of2<T, A1, A2>
 
@@ -102,6 +125,8 @@ namespace test$7 {
 
   declare const box: Box<string>
 
+  const inF = map(x => x, pair).swap()
+  const f = pair.map(x => undefined).swap()
   type Ex = Of<Pair$λ, string>
   const inferred = infer(pair)
   const asV = asVoid(pair)

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -94,10 +94,18 @@ namespace test$7 {
     (): Pair<this[0], this[1]>
   }
 
+  interface PairF<A> extends Pair$λ {
+    (): Pair<A, this[1]>
+  }
+
   declare function infer2<T extends TypeFamily<Kind2>, A1, A2>(t: Of2<T, A1, A2>): Of2<T, A1, A2>
 
   declare const pair: Pair<string, number>
+  declare function asVoid<F, A>(fa: Of<F, A>): Of<F, void>
+
+
   declare const box: Box<string>
 
+  const inferred = asVoid(pair as Of<PairF<string>, number>)
   const x = infer2(pair)
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,5 @@
 import { Generic, TypeFamily, Of, Kind1, Generic1, Kind2, Generic2, Of2 } from ".";
+import { Carrier2 } from "./generics"
 
 declare class Box<A> {
   [Generic.Type]: Generic1<BoxF, A>
@@ -86,7 +87,6 @@ namespace test$6 {
 namespace test$7 {
   class Pair<A, B> {
     [Generic.Type]: Generic2<Pair$λ, A, B>
-
     constructor(readonly _0: A, readonly _1: B) {}
   }
 
@@ -94,18 +94,17 @@ namespace test$7 {
     (): Pair<this[0], this[1]>
   }
 
-  interface PairF<A> extends Pair$λ {
-    (): Pair<A, this[1]>
-  }
-
   declare function infer2<T extends TypeFamily<Kind2>, A1, A2>(t: Of2<T, A1, A2>): Of2<T, A1, A2>
 
   declare const pair: Pair<string, number>
   declare function asVoid<F, A>(fa: Of<F, A>): Of<F, void>
-
+  declare function infer<T, A1>(fa: Of<T, A1>): Of<T, A1>
 
   declare const box: Box<string>
 
-  const inferred = asVoid(pair as Of<PairF<string>, number>)
+  type Ex = Of<Pair$λ, string>
+  const inferred = infer(pair)
+  const asV = asVoid(pair)
+  type Result = Assert<Eq<Pair<string, void>, typeof asV>>
   const x = infer2(pair)
-}
+ }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,28 @@
 import { Kind1, Kind2, Kind3, Kind4 } from "./kinds";
-import { HasGeneric, Generic1, Generic2, Generic3, Generic4, Reduce } from "./generics";
+import {
+  HasGeneric,
+  HasGeneric2,
+  HasGeneric3,
+  HasGeneric4,
+  Generic1,
+  Generic2,
+  Generic3,
+  Generic4,
+  Reduce
+} from "./generics";
 
 export { Kind1, Kind2, Kind3, Kind4 } from "./kinds"
-export { HasGeneric, Generic1, Generic2, Generic3, Generic4, Generic } from "./generics";
+export {
+  HasGeneric,
+  HasGeneric2,
+  HasGeneric3,
+  HasGeneric4,
+  Generic1,
+  Generic2,
+  Generic3,
+  Generic4,
+  Generic
+} from "./generics";
 
 /**
  * A `TypeFamily` type is an encoding for a closed type family. Its type parameter `K` denotes the kind of the type.
@@ -23,16 +43,16 @@ type Generic1$Constraint<T, A1> =
     : HasGeneric<Generic1<TypeFamily<Kind1>, A1>>
 type Generic2$Constraint<T, A1, A2> =
   T extends TypeFamily<Kind2>
-    ? HasGeneric<Generic2<T, A1, A2>>
-    : HasGeneric<Generic2<TypeFamily<Kind2>, A1, A2>>
+    ? HasGeneric2<Generic2<T, A1, A2>>
+    : HasGeneric2<Generic2<TypeFamily<Kind2>, A1, A2>>
 type Generic3$Constraint<T, A1, A2, A3> =
   T extends TypeFamily<Kind3>
-    ? HasGeneric<Generic3<T, A1, A2, A3>>
-    : HasGeneric<Generic3<TypeFamily<Kind3>, A1, A2, A3>>
+    ? HasGeneric3<Generic3<T, A1, A2, A3>>
+    : HasGeneric3<Generic3<TypeFamily<Kind3>, A1, A2, A3>>
 type Generic4$Constraint<T, A1, A2, A3, A4> =
   T extends TypeFamily<Kind4>
-    ? HasGeneric<Generic4<T, A1, A2, A3, A4>>
-    : HasGeneric<Generic4<TypeFamily<Kind4>, A1, A2, A3, A4>>
+    ? HasGeneric4<Generic4<T, A1, A2, A3, A4>>
+    : HasGeneric4<Generic4<TypeFamily<Kind4>, A1, A2, A3, A4>>
 
 /**
  * Transforms `T` and `A` into `T<A>` if `T` extends `TypeFamily`. The bound `HasGeneric<T, A>` is used
@@ -46,11 +66,7 @@ export type Of<T, A> = Of1<T, A>
 export type Of1<T, A1> =
   T extends TypeFamily<Kind1>
     ? Reduce<Generic1<T, A1>>
-    : T extends TypeFamily<Kind2>
-      ? T extends Carrier2<infer L, infer _R>
-        ? Reduce<Generic2<T, L, A1>>
-        : Generic2$Constraint<T, any, A1>
-      : Generic1$Constraint<T, A1>
+    : Generic1$Constraint<T, A1>
 export type Of2<T, A1, A2> =
   T extends TypeFamily<Kind2>
     ? Reduce<Generic2<T, A1, A2>>

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,10 +17,22 @@ export { HasGeneric, Generic1, Generic2, Generic3, Generic4, Generic } from "./g
  */
 export type TypeFamily<K = Kind1> = K
 
-type Generic1$Constraint<T, A1> = T extends TypeFamily<Kind1> ? HasGeneric<Generic1<T, A1>> : HasGeneric<Generic1<TypeFamily<Kind1>, A1>>
-type Generic2$Constraint<T, A1, A2> = T extends TypeFamily<Kind2> ? HasGeneric<Generic2<T, A1, A2>> : HasGeneric<Generic2<TypeFamily<Kind2>, A1, A2>>
-type Generic3$Constraint<T, A1, A2, A3> = T extends TypeFamily<Kind3> ? HasGeneric<Generic3<T, A1, A2, A3>> : HasGeneric<Generic3<TypeFamily<Kind3>, A1, A2, A3>>
-type Generic4$Constraint<T, A1, A2, A3, A4> = T extends TypeFamily<Kind4> ? HasGeneric<Generic4<T, A1, A2, A3, A4>> : HasGeneric<Generic4<TypeFamily<Kind4>, A1, A2, A3, A4>>
+type Generic1$Constraint<T, A1> =
+  T extends TypeFamily<Kind1>
+    ? HasGeneric<Generic1<T, A1>>
+    : HasGeneric<Generic1<TypeFamily<Kind1>, A1>>
+type Generic2$Constraint<T, A1, A2> =
+  T extends TypeFamily<Kind2>
+    ? HasGeneric<Generic2<T, A1, A2>>
+    : HasGeneric<Generic2<TypeFamily<Kind2>, A1, A2>>
+type Generic3$Constraint<T, A1, A2, A3> =
+  T extends TypeFamily<Kind3>
+    ? HasGeneric<Generic3<T, A1, A2, A3>>
+    : HasGeneric<Generic3<TypeFamily<Kind3>, A1, A2, A3>>
+type Generic4$Constraint<T, A1, A2, A3, A4> =
+  T extends TypeFamily<Kind4>
+    ? HasGeneric<Generic4<T, A1, A2, A3, A4>>
+    : HasGeneric<Generic4<TypeFamily<Kind4>, A1, A2, A3, A4>>
 
 /**
  * Transforms `T` and `A` into `T<A>` if `T` extends `TypeFamily`. The bound `HasGeneric<T, A>` is used
@@ -35,8 +47,10 @@ export type Of1<T, A1> =
   T extends TypeFamily<Kind1>
     ? Reduce<Generic1<T, A1>>
     : T extends TypeFamily<Kind2>
-        ? Reduce<Generic2<T, any, A1>>
-        : Generic1$Constraint<T, A1>
+      ? T extends Carrier2<infer L, infer _R>
+        ? Reduce<Generic2<T, L, A1>>
+        : Generic2$Constraint<T, any, A1>
+      : Generic1$Constraint<T, A1>
 export type Of2<T, A1, A2> =
   T extends TypeFamily<Kind2>
     ? Reduce<Generic2<T, A1, A2>>

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ export { Kind1, Kind2, Kind3, Kind4 } from "./kinds"
 export { HasGeneric, Generic1, Generic2, Generic3, Generic4, Generic } from "./generics";
 
 /**
- * A `HFunction` type is an encoding for a closed type family. Its type parameter `K` denotes the kind of the type.
+ * A `TypeFamily` type is an encoding for a closed type family. Its type parameter `K` denotes the kind of the type.
  * For example, a type family with two type parameters has the kind `Kind2`.
  *
  * ```typescript
@@ -31,7 +31,21 @@ type Generic4$Constraint<T, A1, A2, A3, A4> = T extends TypeFamily<Kind4> ? HasG
  * ```
  */
 export type Of<T, A> = Of1<T, A>
-export type Of1<T, A1> = T extends TypeFamily<Kind1> ? Reduce<Generic1<T, A1>> : Generic1$Constraint<T, A1>
-export type Of2<T, A1, A2> = T extends TypeFamily<Kind2> ? Reduce<Generic2<T, A1, A2>> : Generic2$Constraint<T, A1, A2>
-export type Of3<T, A1, A2, A3> = T extends TypeFamily<Kind3> ? Reduce<Generic3<T, A1, A2, A3>> : Generic3$Constraint<T, A1, A2, A3>
-export type Of4<T, A1, A2, A3, A4> = T extends TypeFamily<Kind4> ? Reduce<Generic4<T, A1, A2, A3, A4>> : Generic4$Constraint<T, A1, A2, A3, A4>
+export type Of1<T, A1> =
+  T extends TypeFamily<Kind1>
+    ? Reduce<Generic1<T, A1>>
+    : T extends TypeFamily<Kind2>
+        ? Reduce<Generic2<T, any, A1>>
+        : Generic1$Constraint<T, A1>
+export type Of2<T, A1, A2> =
+  T extends TypeFamily<Kind2>
+    ? Reduce<Generic2<T, A1, A2>>
+    : Generic2$Constraint<T, A1, A2>
+export type Of3<T, A1, A2, A3> =
+  T extends TypeFamily<Kind3>
+    ? Reduce<Generic3<T, A1, A2, A3>>
+    : Generic3$Constraint<T, A1, A2, A3>
+export type Of4<T, A1, A2, A3, A4> =
+  T extends TypeFamily<Kind4>
+    ? Reduce<Generic4<T, A1, A2, A3, A4>>
+    : Generic4$Constraint<T, A1, A2, A3, A4>


### PR DESCRIPTION
Hi!

Thank you for such an awesome library. It is so nice that I've started doing my own prelude based on `tshkt` :)

However implementing `Either` I've run into a bit of a problem. Since kind of either is `* -> * -> *`, I would like to be able to implement some instances (like `Functor`) for partially evaluated `Either`. In order to do so I've defined custom interface like `PairF` from the test. Now this also required a bit of type annotations to work which isn't ideal and some more logic in `Of`.

I saw that in your library `bonsai`, you were able to achieve such result using previous `tshkt` encoding.
But in this version there is single `[Generic.Type]` property per data type (class) and when trying to come up with an approach I was getting clashes on `[witness]` that `K1 /= K2`, hence the `Of` change.

What do you think about this approach? Or did I miss some obvious solution?